### PR TITLE
Add page routing for blog display, heavy WIP

### DIFF
--- a/src/Root.js
+++ b/src/Root.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import MainPage from './components/MainPage/MainPage';
 import LoginPage from './components/LoginPage/LoginPage';
+import BlogDisplay from './components/BlogDisplay/BlogDisplay';
 import Create from './create';
 
 const Root = () => {
@@ -15,6 +16,7 @@ const Root = () => {
           <Route path="/" element={<MainPage />} />
           <Route path="/create" element={<Create />} />
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/articles/:id" element={<BlogDisplay />} />
         </Routes>
       </BrowserRouter>
     </div>

--- a/src/components/BlogDisplay/BlogDisplay.jsx
+++ b/src/components/BlogDisplay/BlogDisplay.jsx
@@ -1,6 +1,7 @@
 import "./BlogDisplay.css"
 import "../../common.css"
 import { useState } from "react";
+import { useParams } from "react-router-dom";
 import React from "react";
 import { Remarkable } from "remarkable"
 import { LoadingAnimation } from "../LoadingAnimation/LoadingAnimation.jsx"
@@ -17,7 +18,9 @@ const ARTICLE_TEST = {
 
 }
 
-export default function BlogDisplay({ article }) {
+export default function BlogDisplay() {
+  const { id } = useParams();
+  const article = ARTICLE_TEST // or api call with id
     return <div style={{position: "relative"}}>
       <Image src={article.contentImg}/>
       <div className="contentcontainer">


### PR DESCRIPTION
Adds a route to the blog display, via /articles/id.

Currently prints out the id directly, and nothing else. This is awaiting for backend to have actual articles, but for the time being every /articles/id is "valid" and portrays @andOrlando 's test article.